### PR TITLE
Baseband phase difference + test

### DIFF
--- a/tests/reconstruction.py
+++ b/tests/reconstruction.py
@@ -377,3 +377,11 @@ def test_torch_vs_base_unspectrogram_twice(segmenter, x):
     segmenter[1].unspectrogram(x_ba)
     assert x_tc.shape == x_ba.shape
     assert x_tc == pytest.approx(x_ba, abs=1e-5)
+    x_tc_mag = segmenter[0].magnitude_spectrogram(x_tc)
+    x_tc_pha = segmenter[0].phase_spectrogram(x_tc)
+    x_tc_bpd = segmenter[0].bpd_transform(x_tc_pha)
+    x_tc_bpd_inv = segmenter[0].inverse_bpd_transform(x_tc_bpd)
+    x_tc_reconstructed = segmenter[0].assemble_spectrogram_magnitude_phase(x_tc_mag, x_tc_pha)
+    assert x_tc == pytest.approx(x_tc_reconstructed, abs=1e-5)
+    x_tc_bpd_reconstructed = segmenter[0].assemble_spectrogram_magnitude_phase(x_tc_mag, x_tc_bpd_inv)
+    assert x_tc == pytest.approx(x_tc_bpd_reconstructed, abs=1e-2)


### PR DESCRIPTION
Added experimental functionality for baseband phase difference representation of the segmented spectrogram + reconstruction error unit test.

Note that due to numerical accuracy (and multiple use of multiplication with pi / modulo of pi operations) the absolute error threshold for the reconstruction is 1e-2, rather than the 1e-5 currently used for the comparable reconstruction error test.

Further note that the baseband phase difference reconstruction seems to accumulate error with increasing number of segments.